### PR TITLE
[#2] Implement MinIO/S3 storage configuration and storage layer structure

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -118,4 +118,4 @@ volumes:
   dbdata:
   minio:
   prometheus-data:
-  grafana-data
+  grafana-data:

--- a/libs/config.py
+++ b/libs/config.py
@@ -1,0 +1,43 @@
+# libs/config.py
+from pydantic_settings import BaseSettings
+from pydantic import Field
+
+class Settings(BaseSettings):
+    # ===== Database Settings =====
+    POSTGRES_USER: str
+    POSTGRES_PASSWORD: str
+    POSTGRES_DB: str
+    POSTGRES_HOST: str = "db"
+    POSTGRES_PORT: int = 5432
+
+    @property
+    def DATABASE_URL(self) -> str:
+        return (
+            f"postgresql+psycopg2://{self.POSTGRES_USER}:"
+            f"{self.POSTGRES_PASSWORD}@{self.POSTGRES_HOST}:"
+            f"{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
+        )
+
+    # ===== Redis / Celery =====
+    REDIS_URL: str
+    CELERY_BROKER_URL: str
+    CELERY_BACKEND_URL: str
+
+    # ===== S3 / MinIO =====
+    S3_ENDPOINT: str = Field(..., description="MinIO or S3 endpoint URL e.g. http://minio:9000")
+    S3_ACCESS_KEY: str
+    S3_SECRET_KEY: str
+    S3_REGION: str = "us-east-1"
+    S3_BUCKET_MODELS: str = "models"
+    S3_BUCKET_ADAPTERS: str = "adapters"
+
+    # ===== Queues for Runners =====
+    QUEUE_PT: str = "pt"
+    QUEUE_ONNX: str = "onnx"
+
+    class Config:
+        env_file = ".env"  # or "configs/.env.dev" in local development
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/services/api/app/routers/models.py
+++ b/services/api/app/routers/models.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, File, UploadFile
+
+router = APIRouter()
+
+@router.post("/models/upload"):
+async def upload_model(file: UploadFile = File(...)):
+    ext = Path(file.filename).suffix.lower()
+    if ext not in [".onnx"]:
+        raise HTTPException(status_code=400, detail="Invalid file extension")
+    
+    save_path = f"models/{file.filename}"
+    filename = file.filename
+    file_content = await file.read()
+    file_path = f"models/{filename}"
+    with open(file_path, "wb") as f:
+        f.write(file_content)
+    
+    return {"filename": file.filename}

--- a/services/api/app/services/storage_service.py
+++ b/services/api/app/services/storage_service.py
@@ -1,0 +1,34 @@
+from fastapi import UploadFile
+from storage.model_store import ModelStore
+from storage.adapter_store import AdapterStore
+from storage.dataset_store import DatasetStore
+
+
+model_store = ModelStore()
+adapter_store = AdapterStore()
+dataset_store = DatasetStore()
+
+def save_model_file(model_id: str, file: UploadFile, version: Optional[int] = None):
+    return model_store.upload_model(
+        model_id = model_id, 
+        file_obj = file.file, 
+        filename = file.filename,
+        version = version,
+    )
+
+
+def save_adapter_file(adapter_id: str, file: UploadFile, base_model_id: str | None = None) -> str:
+    return adapter_store.upload_adapter(
+        adapter_id=adapter_id,
+        file_obj=file.file,
+        filename=file.filename,
+        base_model_id=base_model_id,
+    )
+
+
+def save_dataset_file(dataset_id: str, file: UploadFile) -> str:
+    return dataset_store.upload_dataset(
+        dataset_id=dataset_id,
+        file_obj=file.file,
+        filename=file.filename,
+    )

--- a/storage/adapter_store.py
+++ b/storage/adapter_store.py
@@ -1,0 +1,64 @@
+# storage/adapter_store.py
+
+from typing import BinaryIO, Optional
+from .s3_client import s3_client, S3_BUCKET_ADAPTERS
+
+
+class AdapterStore:
+
+    def __init__(self, bucket: Optional[str] = None, prefix: str = "adapters"):
+        self.s3 = s3_client
+        self.bucket = bucket or S3_BUCKET_ADAPTERS
+        self.prefix = prefix
+
+    def _build_key(
+        self,
+        adapter_id: str,
+        filename: str,
+        base_model_id: Optional[str] = None,
+    ) -> str:
+        if base_model_id:
+            return f"{self.prefix}/{base_model_id}/{adapter_id}/{filename}"
+        return f"{self.prefix}/{adapter_id}/{filename}"
+
+    def upload_adapter(
+        self,
+        adapter_id: str,
+        file_obj: BinaryIO,
+        filename: str,
+        base_model_id: Optional[str] = None,
+    ) -> str:
+        key = self._build_key(
+            adapter_id=adapter_id,
+            filename=filename,
+            base_model_id=base_model_id,
+        )
+        self.s3.upload_fileobj(file_obj, self.bucket, key)
+        return key
+
+    def download_adapter(
+        self,
+        adapter_id: str,
+        filename: str,
+        base_model_id: Optional[str] = None,
+    ) -> bytes:
+        key = self._build_key(
+            adapter_id=adapter_id,
+            filename=filename,
+            base_model_id=base_model_id,
+        )
+        obj = self.s3.get_object(Bucket=self.bucket, Key=key)
+        return obj["Body"].read()
+
+    def delete_adapter(
+        self,
+        adapter_id: str,
+        filename: str,
+        base_model_id: Optional[str] = None,
+    ) -> None:
+        key = self._build_key(
+            adapter_id=adapter_id,
+            filename=filename,
+            base_model_id=base_model_id,
+        )
+        self.s3.delete_object(Bucket=self.bucket, Key=key)

--- a/storage/dataset_store.py
+++ b/storage/dataset_store.py
@@ -1,0 +1,42 @@
+# storage/dataset_store.py
+
+from typing import BinaryIO
+from .s3_client import s3_client, S3_BUCKET_DATASETS
+
+
+class DatasetStore:
+
+    def __init__(self, bucket: str | None = None, prefix: str = "datasets"):
+        self.s3 = s3_client
+        self.bucket = bucket or S3_BUCKET_DATASETS
+        self.prefix = prefix
+
+    def _build_key(self, dataset_id: str, filename: str) -> str:
+        return f"{self.prefix}/{dataset_id}/{filename}"
+
+    def upload_dataset(
+        self,
+        dataset_id: str,
+        file_obj: BinaryIO,
+        filename: str,
+    ) -> str:
+        key = self._build_key(dataset_id, filename)
+        self.s3.upload_fileobj(file_obj, self.bucket, key)
+        return key
+
+    def download_dataset(
+        self,
+        dataset_id: str,
+        filename: str,
+    ) -> bytes:
+        key = self._build_key(dataset_id, filename)
+        obj = self.s3.get_object(Bucket=self.bucket, Key=key)
+        return obj["Body"].read()
+
+    def delete_dataset(
+        self,
+        dataset_id: str,
+        filename: str,
+    ) -> None:
+        key = self._build_key(dataset_id, filename)
+        self.s3.delete_object(Bucket=self.bucket, Key=key)

--- a/storage/model_store.py
+++ b/storage/model_store.py
@@ -1,0 +1,51 @@
+
+from typing import BinaryIO, Optional
+from .s3_client import s3_client, S3_BUCKET_MODELS
+
+
+class ModelStore:
+
+    def __init__(self, bucket: Optional[str] = None, prefix: str = "models"):
+        self.s3 = s3_client
+        self.bucket = bucket or S3_BUCKET_MODELS
+        self.prefix = prefix
+
+    def _build_key(
+        self,
+        model_id: str,
+        filename: str,
+        version: Optional[int] = None,
+    ) -> str:
+        if version is None:
+            return f"{self.prefix}/{model_id}/{filename}"
+        return f"{self.prefix}/{model_id}/v{version}/{filename}"
+
+    def upload_model(
+        self,
+        model_id: str,
+        file_obj: BinaryIO,
+        filename: str,
+        version: Optional[int] = None,
+    ) -> str:
+        key = self._build_key(model_id=model_id, filename=filename, version=version)
+        self.s3.upload_fileobj(file_obj, self.bucket, key)
+        return key
+
+    def download_model(
+        self,
+        model_id: str,
+        filename: str,
+        version: Optional[int] = None,
+    ) -> bytes:
+        key = self._build_key(model_id=model_id, filename=filename, version=version)
+        obj = self.s3.get_object(Bucket=self.bucket, Key=key)
+        return obj["Body"].read()
+
+    def delete_model_file(
+        self,
+        model_id: str,
+        filename: str,
+        version: Optional[int] = None,
+    ) -> None:
+        key = self._build_key(model_id=model_id, filename=filename, version=version)
+        self.s3.delete_object(Bucket=self.bucket, Key=key)

--- a/storage/s3_client.py
+++ b/storage/s3_client.py
@@ -1,0 +1,28 @@
+import boto3
+from typing import Any, Dict
+from libs.config import settings
+
+def get_s3_client() :
+    common_kwargs: Dict[str, Any] = {
+        "aws_access_key_id": settings.S3_ACCESS_KEY,
+        "aws_secret_access_key": settings.S3_SECRET_KEY,
+        "region_name": settings.S3_REGION,
+    }
+
+    if settings.STORAGE_BACKEND == "minio":
+        return boto3.client(
+            "s3",
+            endpoint_url=settings.S3_ENDPOINT,
+            **common_kwargs
+        )
+    elif settings.STORAGE_BACKEND == "aws":
+        return boto3.client(
+            "s3",
+            **common_kwargs
+        )
+    else:
+        raise ValueError(f"Invalid storage backend: {settings.STORAGE_BACKEND}")
+
+s3_client = get_s3_client()
+S3_BUCKET_MODELS = settings.S3_BUCKET_MODELS
+S3_BUCKET_ADAPTERS = settings.S3_BUCKET_ADAPTERS


### PR DESCRIPTION
## Summary
This PR implements the foundational storage layer for InsightHub, enabling MinIO and AWS S3 compatibility.
It introduces a shared storage client, configurable via environment variables, and provides domain-based storage classes
(ModelStore, AdapterStore, DatasetStore) for handling different types of stored artifacts.

---

## Changes
### 🔧 Storage Configuration & Client
- Added storage-related configuration fields to `libs/config.py`
- Implemented `get_s3_client()` in `storage/s3_client.py` to support both MinIO (dev) & AWS S3 (prod)
- Added backend switching using `STORAGE_BACKEND` (minio / aws)
- Exposed bucket names using `settings.S3_BUCKET_MODELS` and `settings.S3_BUCKET_ADAPTERS`

### 📦 Storage Layer (Domain-Based Stores)
- Implemented `ModelStore`, `AdapterStore`, and `DatasetStore` classes
- Added structured S3 key patterns:
  - `models/{model_id}/v{version}/{filename}`
  - `adapters/{adapter_id}/{filename}`
  - `datasets/{dataset_id}/{filename}`
- Applied separation of concerns for model/artifact handling

### 🏗 Project Structure Update
storage/
├── s3_client.py
├── model_store.py
├── adapter_store.py
└── dataset_store.py


---

## Notes
- API integration (file upload via endpoint) is **not** included in this PR (will be handled in Issue #8)
- Runner integration and metadata persistence will be addressed in future issues

---

## Related Issue
Closes #2
